### PR TITLE
fix: release artifact collection on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,9 @@ jobs:
         shell: bash
         run: |
           mkdir -p release-assets
-          shopt -s globstar nullglob
+          shopt -s nullglob
           matched=0
-          for file in src-tauri/target/release/bundle/**/${{ matrix.artifact_pattern }}; do
+          for file in src-tauri/target/release/bundle/${{ matrix.bundle }}/${{ matrix.artifact_pattern }}; do
             cp "$file" release-assets/
             matched=1
           done


### PR DESCRIPTION
## Summary
- remove unsupported `globstar` dependency in release artifact collection step
- use portable non-recursive bundle glob for linux/macos outputs
- fail early with a clear error when no bundle artifact is found